### PR TITLE
Add use_jit option to URDFparser interface

### DIFF
--- a/urdf2casadi/urdfparser.py
+++ b/urdf2casadi/urdfparser.py
@@ -14,11 +14,12 @@ import urdf2casadi.geometry.dual_quaternion as dual_quaternion
 class URDFparser(object):
     """Class that turns a chain from URDF to casadi functions."""
     actuated_types = ["prismatic", "revolute", "continuous"]
-    func_opts = {"jit": True, "jit_options": {"flags": "-Ofast"}}
+    func_opts = {}
+    jit_func_opts = {"jit": True, "jit_options": {"flags": "-Ofast"}}
     # OS/CPU dependent specification of compiler
     if system() == "darwin" or machine() == "aarch64":
-        func_opts["compiler"] = "shell"
-    
+        jit_func_opts["compiler"] = "shell"
+
     def __init__(self, func_opts=None):
         self.robot_desc = None
         if func_opts:

--- a/urdf2casadi/urdfparser.py
+++ b/urdf2casadi/urdfparser.py
@@ -20,10 +20,14 @@ class URDFparser(object):
     if system() == "darwin" or machine() == "aarch64":
         jit_func_opts["compiler"] = "shell"
 
-    def __init__(self, func_opts=None):
+    def __init__(self, func_opts=None, use_jit=True):
         self.robot_desc = None
         if func_opts:
             self.func_opts = func_opts
+        if use_jit:
+            # NOTE: use_jit=True requires that CasADi is built with Clang
+            for k, v in self.jit_func_opts.items():
+                self.func_opts[k] = v
 
     def from_file(self, filename):
         """Uses an URDF file to get robot description."""


### PR DESCRIPTION
Hi, first, nice package! However, it didn't work out-of-the-box for me - even `pip install urdf2casadi` doesn't work. I believe the issue is that you use `jit` options by default when instantiating the `URDFparser` class for function objects. This requires casadi to be built with the `--WITH_CLANG` option on.

Can I suggest you merge this commit, that just defaults to no options instead.