### PR TITLE
Handle missing origin for fixed joints

### DIFF
--- a/urdf2casadi/urdfparser.py
+++ b/urdf2casadi/urdfparser.py
@@ -584,8 +584,13 @@ class URDFparser(object):
         i = 0
         for joint in joint_list:
             if joint.type == "fixed":
-                xyz = joint.origin.xyz
-                rpy = joint.origin.rpy
+                if joint.origin is not None:
+                    xyz = joint.origin.xyz
+                    rpy = joint.origin.rpy
+                else:
+                    # origin tag not given -> assume zero
+                    xyz = [0.0]*3
+                    rpy = [0.0]*3
                 joint_frame = T.numpy_rpy(xyz, *rpy)
                 joint_quaternion = quaternion.numpy_rpy(*rpy)
                 joint_dual_quat = dual_quaternion.numpy_prismatic(


### PR DESCRIPTION
Simple fix for the case when a URDF contains fixed joints with a spec like the following
```xml
  <joint name="base_to_waist" type="fixed">
    <parent link="myrobot_base"/>
    <child link="myrobot_waist"/>
  </joint>
```
Otherwise, an `AttributeError` is thrown.