### PR TITLE
Add Dockerfile and docker compose to run the example in a containerized form

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.9-slim-buster
+
+# Install necessary packages and clean up
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    pipx \
+    python3-venv \
+    && apt-get clean all \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Poetry using pipx
+RUN pipx install poetry==1.5.1
+
+# Set the virtual environment path
+ENV POETRY_VIRTUALENVS_IN_PROJECT=true
+ENV POETRY_VIRTUALENVS_PATH=/project/.venv
+
+# Set the working directory
+WORKDIR /project
+
+# Copy the project files
+COPY . ./
+
+# Install the project dependencies
+RUN /root/.local/bin/poetry install
+
+# Add the virtual environment to the PATH and source it
+ENV PATH="/project/.venv/bin:$PATH"
+RUN echo 'source /project/.venv/bin/activate' >> ~/.bashrc
+
+# Default command to run when starting the container
+# CMD ["bash"]
+ENTRYPOINT ["python", "examples/user/ur5_example.py"]

--- a/.docker/docker-compose.yaml
+++ b/.docker/docker-compose.yaml
@@ -1,0 +1,12 @@
+---
+services:
+  urdf2casadi:
+    build:
+      context: ..
+      dockerfile: .docker/Dockerfile
+    # entrypoint: ["bash"]  # uncomment this to start into console
+    # entrypoint: ["python", "examples/user/ur5_example.py"]  # specify a custom file to run
+    image: urdf2casadi
+    volumes:
+      - ../urdf2casadi:/project/urdf2casadi
+      - ../examples:/project/examples

--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ forward_kinematics = fk_dict["T_fk"]
 print(forward_kinematics([0.3, 0.3, 0.3, 0., 0.3, 0.7]))
 ```
 
+## Docker
+
+You can use [Docker](https://www.docker.com) with docker compose to run the example ur5_example.py.
+
+First, build your docker image via
+
+```bash
+cd .docker
+docker compose build
+```
+
+Then, you can run the example from examples/user/ur5_example.py via
+
+```bash
+docker compose run urdf2casadi
+```
+
+This prints the result of the example to the console.
+
 ## Citation
 The results were published in "Robot Dynamics with URDF & CasADi" at ICCMA 2019. [[Preprint](http://folk.ntnu.no/tomgra/papers/Johannessen_ICCMA_2019_paper_23%20.pdf)]
 ```


### PR DESCRIPTION
This adds a Dockerfile and a docker-compose file to run the example in a containerized form without having to install anything locally.